### PR TITLE
CHAINS-6848 upgrade go in forked btcd dockerfile

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -5,7 +5,7 @@
 ###########################
 # Build binaries stage
 ###########################
-FROM --platform=$BUILDPLATFORM golang:1.22.11-alpine3.21 AS build
+FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS build
 ADD . /app
 WORKDIR /app
 # Arguments required to build binaries targetting the correct OS and CPU architectures


### PR DESCRIPTION
Upgrades the Dockerfile base image from golang:1.22.11-alpine3.21 to golang:1.23-alpine to resolve build failures caused by a version mismatch between the Docker build environment and the go.mod requirement of Go 1.23.2, which was preventing multi-architecture builds from completing successfully across amd64, arm64, arm/v7, and 386 platforms.
